### PR TITLE
Initialize CLITracker skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and fill in your Pivotal Tracker API token
+PT_API_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ target/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Added by cargo
+
+/target
+.env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "clitracker"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ncurses = "5.101.0"
+reqwest = { version = "0.11", features = ["json", "blocking"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+dotenvy = "0.15"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # clitracker
 CLITracker is a Rust-based terminal productivity tool with an ncurses UI. It integrates with Pivotal Tracker’s API to fetch, update, and manage tasks from your command line. Designed for developers who live in the terminal, it keeps you focused and efficient without switching to a browser.
+
+## Development Setup
+
+1. Copy `.env.example` to `.env` and add your Pivotal Tracker API token.
+2. Build and run the application with `cargo run`.
+
+This project uses ncurses for a terminal UI and reqwest for interacting with the Pivotal Tracker API. The current implementation contains stub functions and a basic menu layout.

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,36 @@
+use crate::models::{Project, Story};
+use dotenvy::dotenv;
+use reqwest::blocking::Client;
+use std::env;
+
+const BASE_URL: &str = "https://www.pivotaltracker.com/services/v5";
+
+pub struct Api {
+    client: Client,
+    token: String,
+}
+
+impl Api {
+    pub fn new() -> Self {
+        dotenv().ok();
+        let token = env::var("PT_API_TOKEN").unwrap_or_default();
+        let client = Client::new();
+        Api { client, token }
+    }
+
+    pub fn get_projects(&self) -> Result<Vec<Project>, reqwest::Error> {
+        // Stub: fetch projects
+        let _ = self;
+        Ok(vec![])
+    }
+
+    pub fn get_stories(&self, _project_id: u64) -> Result<Vec<Story>, reqwest::Error> {
+        // Stub: fetch stories for a project
+        Ok(vec![])
+    }
+
+    pub fn update_story_state(&self, _story_id: u64, _state: &str) -> Result<(), reqwest::Error> {
+        // Stub: update story state
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,12 @@
+mod api;
+mod models;
+mod ui;
+
+use ui::Ui;
+
+fn main() {
+    let ui = Ui::new();
+    ui.init();
+    ui.main_menu();
+    ui.end();
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Project {
+    pub id: u64,
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Story {
+    pub id: u64,
+    pub name: String,
+    #[serde(rename = "current_state")]
+    pub current_state: String,
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,43 @@
+use crate::api::Api;
+use ncurses::*;
+
+pub enum MenuItem {
+    Projects,
+    Stories,
+    Update,
+    Exit,
+}
+
+pub struct Ui {
+    api: Api,
+}
+
+impl Ui {
+    pub fn new() -> Self {
+        Ui { api: Api::new() }
+    }
+
+    pub fn init(&self) {
+        initscr();
+        keypad(stdscr(), true);
+        noecho();
+    }
+
+    pub fn end(&self) {
+        endwin();
+    }
+
+    pub fn main_menu(&self) {
+        // Stub: main menu loop
+        self.print_menu();
+    }
+
+    fn print_menu(&self) {
+        mvprintw(0, 0, "CLITracker");
+        mvprintw(2, 0, "[1] View My Projects");
+        mvprintw(3, 0, "[2] View Stories by Project");
+        mvprintw(4, 0, "[3] Update Story Status");
+        mvprintw(5, 0, "[4] Exit");
+        refresh();
+    }
+}


### PR DESCRIPTION
## Summary
- bootstrap Rust project
- add ui, api, and models modules
- basic main menu with ncurses
- stubbed API layer and data models
- document setup steps

## Testing
- `cargo build` *(fails: failed to download crates)*
- `cargo fmt` *(fails: rustfmt component missing)*